### PR TITLE
the --version and --help flags always work

### DIFF
--- a/internal/task/builder.go
+++ b/internal/task/builder.go
@@ -274,7 +274,7 @@ func parseInfo(text []byte) (string, error) {
 		lang = string(all[1])
 	}
 
-	if len(all) <= 2 { //nolint:gomnd
+	if len(all) <= reInfo.NumSubexp() {
 		return lang, nil
 	}
 

--- a/releases/v0.1.2.md
+++ b/releases/v0.1.2.md
@@ -1,0 +1,9 @@
+cdo `v0.1.2` is here 🎉!
+
+This release includes the following bugfix:
+
+- [#6 The --version and --help flags should always work](The --version and --help flags should always work)
+
+If there is an error parsing task definitions, or no task definitions are found, cdo previously exits with an error message, even if it should only handle the `--version` or `--help` flags.
+
+The `--version` and `--help` flag handling now always works, regardless of the presence or parsability of task definitions.


### PR DESCRIPTION
If there is an error parsing task definitions, or no task definitions are found, cdo previously exits with an error message, even if it should only handle the `--version` or `--help` flags.

The `--version` and `--help` flag handling now always works, regardless of the presence or parsability of task definitions.
